### PR TITLE
Feature implementation from commits 964f269..9849d27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ ui/dist/app/*
 !ui/dist/app/gitkeep
 site/
 *.iml
+.tilt-bin/
 # delve debug binaries
 cmd/**/debug
 debug.test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -64,7 +64,6 @@ linters:
         - importShadow
         - paramTypeCombine # Leave disabled, there are too many failures to be worth fixing.
         - rangeValCopy
-        - sloppyReassign
         - tooManyResultsChecker
         - unnamedResult
         - whyNoLint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -59,7 +59,6 @@ linters:
         - deferInLoop
         - exitAfterDefer
         - exposedSyncMutex
-        - filepathJoin
         - hugeParam
         - importShadow
         - paramTypeCombine # Leave disabled, there are too many failures to be worth fixing.

--- a/Dockerfile.tilt
+++ b/Dockerfile.tilt
@@ -1,0 +1,62 @@
+FROM docker.io/library/golang:1.24.1@sha256:c5adecdb7b3f8c5ca3c88648a861882849cc8b02fed68ece31e25de88ad13418 
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN echo 'deb http://archive.debian.org/debian buster-backports main' >> /etc/apt/sources.list
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    curl \
+    openssh-server \
+    nginx \
+    unzip \
+    fcgiwrap \
+    git \
+    git-lfs \
+    make \
+    wget \
+    gcc \
+    sudo \
+    zip \
+    tini \
+    gpg \
+    tzdata \
+    connect-proxy
+
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+COPY hack/install.sh hack/tool-versions.sh ./
+COPY hack/installers installers
+
+RUN ./install.sh helm && \
+    INSTALL_PATH=/usr/local/bin ./install.sh kustomize
+
+COPY hack/gpg-wrapper.sh \
+    hack/git-verify-wrapper.sh \
+    entrypoint.sh \
+    /usr/local/bin/
+
+# support for mounting configuration from a configmap
+WORKDIR /app/config/ssh
+RUN touch ssh_known_hosts && \
+    ln -s /app/config/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts
+
+WORKDIR /app/config
+RUN mkdir -p tls && \
+    mkdir -p gpg/source && \
+    mkdir -p gpg/keys 
+
+COPY .tilt-bin/argocd_linux /usr/local/bin/argocd
+
+RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-server && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-repo-server && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-application-controller && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-dex && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-notifications && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-applicationset-controller && \
+    ln -s /usr/local/bin/argocd /usr/local/bin/argocd-commit-server
+
+# directory for Tilt restart file
+RUN mkdir -p /tilt
+
+# overridden by Tiltfile
+ENTRYPOINT ["/usr/bin/tini", "-s", "--", "dlv", "exec", "--continue", "--accept-multiclient", "--headless", "--listen=:2345", "--api-version=2"]

--- a/Dockerfile.ui.tilt
+++ b/Dockerfile.ui.tilt
@@ -1,0 +1,9 @@
+FROM node:20
+
+WORKDIR /app/ui
+
+COPY ui /app/ui
+
+RUN yarn install
+
+ENTRYPOINT ["yarn", "start"]

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,282 @@
+load('ext://restart_process', 'docker_build_with_restart')
+load('ext://uibutton', 'cmd_button', 'location')
+
+# add ui button in web ui to run make codegen-local (top nav)
+cmd_button(
+    'make codegen-local',
+    argv=['sh', '-c', 'make codegen-local'],
+    location=location.NAV,
+    icon_name='terminal',
+    text='make codegen-local',
+)
+
+# add ui button in web ui to run make codegen-local (top nav)
+cmd_button(
+    'make cli-local',
+    argv=['sh', '-c', 'make cli-local'],
+    location=location.NAV,
+    icon_name='terminal',
+    text='make cli-local',
+)
+
+# detect cluster architecture for build
+cluster_version = decode_yaml(local('kubectl version -o yaml'))
+platform = cluster_version['serverVersion']['platform']
+arch = platform.split('/')[1]
+
+# build the argocd binary on code changes
+code_deps = [
+    'applicationset',
+    'cmd',
+    'cmpserver',
+    'commitserver',
+    'common',
+    'controller',
+    'notification-controller',
+    'pkg',
+    'reposerver',
+    'server',
+    'util',
+    'go.mod',
+    'go.sum',
+]
+local_resource(
+    'build',
+    'CGO_ENABLED=0 GOOS=linux GOARCH=' + arch + ' go build -gcflags="all=-N -l" -mod=readonly -o .tilt-bin/argocd_linux cmd/main.go',
+    deps = code_deps,
+    allow_parallel=True,
+)
+
+# deploy the argocd manifests
+k8s_yaml(kustomize('manifests/dev-tilt'))
+
+# build dev image
+docker_build_with_restart(
+    'argocd', 
+    context='.',
+    dockerfile='Dockerfile.tilt',
+    entrypoint=[
+        "/usr/bin/tini",
+        "-s",
+        "--",
+        "dlv",
+        "exec",
+        "--continue",
+        "--accept-multiclient",
+        "--headless",
+        "--listen=:2345",
+        "--api-version=2"
+    ],
+    platform=platform,
+    live_update=[
+        sync('.tilt-bin/argocd_linux_amd64', '/usr/local/bin/argocd'),
+    ],
+    only=[
+        '.tilt-bin',
+        'hack',
+        'entrypoint.sh',
+    ],
+    restart_file='/tilt/.restart-proc'
+)
+
+# build image for argocd-cli jobs
+docker_build(
+    'argocd-job', 
+    context='.',
+    dockerfile='Dockerfile.tilt',
+    platform=platform,
+    only=[
+        '.tilt-bin',
+        'hack',
+        'entrypoint.sh',
+    ]
+)
+
+# track argocd-server resources and port forward
+k8s_resource(
+    workload='argocd-server',
+    objects=[
+        'argocd-server:serviceaccount',
+        'argocd-server:role',
+        'argocd-server:rolebinding',
+        'argocd-cm:configmap',
+        'argocd-cmd-params-cm:configmap',
+        'argocd-gpg-keys-cm:configmap',
+        'argocd-rbac-cm:configmap',
+        'argocd-ssh-known-hosts-cm:configmap',
+        'argocd-tls-certs-cm:configmap',
+        'argocd-secret:secret',
+        'argocd-server-network-policy:networkpolicy',
+        'argocd-server:clusterrolebinding',
+        'argocd-server:clusterrole',
+    ],
+    port_forwards=[
+        '8080:8080',
+        '9345:2345',
+        '8083:8083'
+    ],
+)
+
+# track crds
+k8s_resource(
+    new_name='cluster-resources',
+    objects=[
+        'applications.argoproj.io:customresourcedefinition',
+        'applicationsets.argoproj.io:customresourcedefinition',
+        'appprojects.argoproj.io:customresourcedefinition',
+        'argocd:namespace'
+    ]
+)
+
+# track argocd-repo-server resources and port forward
+k8s_resource(
+    workload='argocd-repo-server',
+    objects=[
+        'argocd-repo-server:serviceaccount',
+        'argocd-repo-server-network-policy:networkpolicy',
+    ],
+    port_forwards=[
+        '8081:8081',
+        '9346:2345',
+        '8084:8084'
+    ],
+)
+
+# track argocd-redis resources and port forward
+k8s_resource(
+    workload='argocd-redis',
+    objects=[
+        'argocd-redis:serviceaccount',
+        'argocd-redis:role',
+        'argocd-redis:rolebinding',
+        'argocd-redis-network-policy:networkpolicy',
+    ],
+    port_forwards=[
+        '6379:6379',
+    ],
+)
+
+# track argocd-applicationset-controller resources
+k8s_resource(
+    workload='argocd-applicationset-controller',
+    objects=[
+        'argocd-applicationset-controller:serviceaccount',
+        'argocd-applicationset-controller-network-policy:networkpolicy',
+        'argocd-applicationset-controller:role',
+        'argocd-applicationset-controller:rolebinding',
+        'argocd-applicationset-controller:clusterrolebinding',
+        'argocd-applicationset-controller:clusterrole',
+    ],
+    port_forwards=[
+        '9347:2345',
+        '8085:8080',
+        '7000:7000'
+    ],
+)
+
+# track argocd-application-controller resources
+k8s_resource(
+    workload='argocd-application-controller',
+    objects=[
+        'argocd-application-controller:serviceaccount',
+        'argocd-application-controller-network-policy:networkpolicy',
+        'argocd-application-controller:role',
+        'argocd-application-controller:rolebinding',
+        'argocd-application-controller:clusterrolebinding',
+        'argocd-application-controller:clusterrole',
+    ],
+    port_forwards=[
+        '9348:2345',
+        '8086:8082',
+    ],
+)
+
+# track argocd-notifications-controller resources
+k8s_resource(
+    workload='argocd-notifications-controller',
+    objects=[
+        'argocd-notifications-controller:serviceaccount',
+        'argocd-notifications-controller-network-policy:networkpolicy',
+        'argocd-notifications-controller:role',
+        'argocd-notifications-controller:rolebinding',
+        'argocd-notifications-cm:configmap',
+        'argocd-notifications-secret:secret',
+    ],
+    port_forwards=[
+        '9349:2345',
+        '8087:9001',
+    ],
+)
+
+# track argocd-dex-server resources
+k8s_resource(
+    workload='argocd-dex-server',
+    objects=[
+        'argocd-dex-server:serviceaccount',
+        'argocd-dex-server-network-policy:networkpolicy',
+        'argocd-dex-server:role',
+        'argocd-dex-server:rolebinding',
+    ],
+)
+
+# track argocd-commit-server resources
+k8s_resource(
+    workload='argocd-commit-server',
+    objects=[
+        'argocd-commit-server:serviceaccount',
+        'argocd-commit-server-network-policy:networkpolicy',
+    ],
+    port_forwards=[
+        '9350:2345',
+        '8088:8087',
+        '8089:8086',
+    ],
+)
+
+# docker for ui
+docker_build(
+    'argocd-ui',
+    context='.',
+    dockerfile='Dockerfile.ui.tilt',
+    entrypoint=['sh', '-c', 'cd /app/ui && yarn start'], 
+    only=['ui'],
+    live_update=[
+        sync('ui', '/app/ui'),
+        run('sh -c "cd /app/ui && yarn install"', trigger=['/app/ui/package.json', '/app/ui/yarn.lock']),
+    ],
+)
+
+# track argocd-ui resources and port forward
+k8s_resource(
+    workload='argocd-ui',
+    port_forwards=[
+        '4000:4000',
+    ],
+)
+
+# linting
+local_resource(
+    'lint',
+    'make lint-local',
+    deps = code_deps,
+    allow_parallel=True,
+)
+
+local_resource(
+    'lint-ui',
+    'make lint-ui-local',
+    deps = [
+        'ui',
+    ],
+    allow_parallel=True,
+)
+
+local_resource(
+    'vendor',
+    'go mod vendor',
+    deps = [
+        'go.mod',
+        'go.sum',
+    ],
+)
+

--- a/applicationset/controllers/template/patch_test.go
+++ b/applicationset/controllers/template/patch_test.go
@@ -27,7 +27,7 @@ func Test_ApplyTemplatePatch(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "my-cluster-guestbook",
 					Namespace:  "namespace",
-					Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+					Finalizers: []string{appv1.ResourcesFinalizerName},
 				},
 				Spec: appv1.ApplicationSpec{
 					Project: "default",
@@ -72,7 +72,7 @@ func Test_ApplyTemplatePatch(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "my-cluster-guestbook",
 					Namespace:  "namespace",
-					Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+					Finalizers: []string{appv1.ResourcesFinalizerName},
 					Annotations: map[string]string{
 						"annotation-some-key": "annotation-some-value",
 					},
@@ -112,7 +112,7 @@ func Test_ApplyTemplatePatch(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "my-cluster-guestbook",
 					Namespace:  "namespace",
-					Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+					Finalizers: []string{appv1.ResourcesFinalizerName},
 				},
 				Spec: appv1.ApplicationSpec{
 					Project: "default",
@@ -148,7 +148,7 @@ spec:
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "my-cluster-guestbook",
 					Namespace:  "namespace",
-					Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+					Finalizers: []string{appv1.ResourcesFinalizerName},
 					Annotations: map[string]string{
 						"annotation-some-key": "annotation-some-value",
 					},

--- a/applicationset/services/scm_provider/aws_codecommit.go
+++ b/applicationset/services/scm_provider/aws_codecommit.go
@@ -340,7 +340,7 @@ func toAbsolutePath(path string) string {
 	if filepath.IsAbs(path) {
 		return path
 	}
-	return filepath.ToSlash(filepath.Join("/", path))
+	return filepath.ToSlash(filepath.Join("/", path)) //nolint:gocritic // Prepend slash to have an absolute path
 }
 
 func createAWSDiscoveryClients(_ context.Context, role string, region string) (*resourcegroupstaggingapi.ResourceGroupsTaggingAPI, *codecommit.CodeCommit, error) {

--- a/applicationset/utils/utils.go
+++ b/applicationset/utils/utils.go
@@ -276,7 +276,7 @@ func (r *Render) RenderTemplateParams(tmpl *argoappsv1.Application, syncPolicy *
 	// See TestRenderTemplateParamsFinalizers in util_test.go for test-based definition of behaviour
 	if (syncPolicy == nil || !syncPolicy.PreserveResourcesOnDeletion) &&
 		len(replacedTmpl.Finalizers) == 0 {
-		replacedTmpl.Finalizers = []string{"resources-finalizer.argocd.argoproj.io"}
+		replacedTmpl.Finalizers = []string{argoappsv1.ResourcesFinalizerName}
 	}
 
 	return replacedTmpl, nil

--- a/applicationset/utils/utils_test.go
+++ b/applicationset/utils/utils_test.go
@@ -752,35 +752,35 @@ func TestRenderTemplateParamsFinalizers(t *testing.T) {
 		},
 		{
 			testName:           "background finalizer should be preserved",
-			existingFinalizers: []string{"resources-finalizer.argocd.argoproj.io/background"},
+			existingFinalizers: []string{argoappsv1.BackgroundPropagationPolicyFinalizer},
 			syncPolicy:         nil,
-			expectedFinalizers: []string{"resources-finalizer.argocd.argoproj.io/background"},
+			expectedFinalizers: []string{argoappsv1.BackgroundPropagationPolicyFinalizer},
 		},
 
 		{
 			testName:           "empty finalizer and empty sync should use standard finalizer",
 			existingFinalizers: nil,
 			syncPolicy:         nil,
-			expectedFinalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			expectedFinalizers: []string{argoappsv1.ResourcesFinalizerName},
 		},
 
 		{
 			testName:           "standard finalizer should be preserved",
-			existingFinalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			existingFinalizers: []string{argoappsv1.ResourcesFinalizerName},
 			syncPolicy:         nil,
-			expectedFinalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			expectedFinalizers: []string{argoappsv1.ResourcesFinalizerName},
 		},
 		{
 			testName:           "empty array finalizers should use standard finalizer",
 			existingFinalizers: []string{},
 			syncPolicy:         nil,
-			expectedFinalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			expectedFinalizers: []string{argoappsv1.ResourcesFinalizerName},
 		},
 		{
 			testName:           "non-nil sync policy should use standard finalizer",
 			existingFinalizers: nil,
 			syncPolicy:         &argoappsv1.ApplicationSetSyncPolicy{},
-			expectedFinalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			expectedFinalizers: []string{argoappsv1.ResourcesFinalizerName},
 		},
 		{
 			testName:           "preserveResourcesOnDeletion should not have a finalizer",
@@ -792,11 +792,11 @@ func TestRenderTemplateParamsFinalizers(t *testing.T) {
 		},
 		{
 			testName:           "user-specified finalizer should overwrite preserveResourcesOnDeletion",
-			existingFinalizers: []string{"resources-finalizer.argocd.argoproj.io/background"},
+			existingFinalizers: []string{argoappsv1.BackgroundPropagationPolicyFinalizer},
 			syncPolicy: &argoappsv1.ApplicationSetSyncPolicy{
 				PreserveResourcesOnDeletion: true,
 			},
-			expectedFinalizers: []string{"resources-finalizer.argocd.argoproj.io/background"},
+			expectedFinalizers: []string{argoappsv1.BackgroundPropagationPolicyFinalizer},
 		},
 	} {
 		t.Run(c.testName, func(t *testing.T) {

--- a/cmd/argocd/commands/admin/app.go
+++ b/cmd/argocd/commands/admin/app.go
@@ -117,7 +117,7 @@ func NewGenAppSpecCommand() *cobra.Command {
 				os.Exit(1)
 			}
 			if setFinalizer {
-				app.Finalizers = append(app.Finalizers, "resources-finalizer.argocd.argoproj.io")
+				app.Finalizers = append(app.Finalizers, v1alpha1.ResourcesFinalizerName)
 			}
 			out, closer, err := getOutWriter(inline, fileURL)
 			errors.CheckError(err)

--- a/cmd/argocd/commands/admin/repo.go
+++ b/cmd/argocd/commands/admin/repo.go
@@ -70,13 +70,13 @@ func NewGenRepoSpecCommand() *cobra.Command {
   argocd admin repo generate-spec helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type helm --name stable --enable-oci --username test --password test
 
   # Add a private HTTPS OCI repository named 'stable'
-  argocd repo generate-spec oci://helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type oci --name stable --username test --password test
+  argocd admin repo generate-spec oci://helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type oci --name stable --username test --password test
   
   # Add a private OCI repository named 'stable' without verifying the server's TLS certificate
-  argocd repo generate-spec oci://helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type oci --name stable --username test --password test --insecure-skip-server-verification
+  argocd admin repo generate-spec oci://helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type oci --name stable --username test --password test --insecure-skip-server-verification
   
   # Add a private HTTP OCI repository named 'stable'
-  argocd repo generate-spec oci://helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type oci --name stable --username test --password test --insecure-oci-force-http
+  argocd admin repo generate-spec oci://helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type oci --name stable --username test --password test --insecure-oci-force-http
 `
 
 	command := &cobra.Command{

--- a/cmd/argocd/commands/app.go
+++ b/cmd/argocd/commands/app.go
@@ -167,7 +167,7 @@ func NewApplicationCreateCommand(clientOpts *argocdclient.ClientOptions) *cobra.
 					app.Namespace = appNamespace
 				}
 				if setFinalizer {
-					app.Finalizers = append(app.Finalizers, "resources-finalizer.argocd.argoproj.io")
+					app.Finalizers = append(app.Finalizers, argoappv1.ResourcesFinalizerName)
 				}
 				conn, appIf := argocdClient.NewApplicationClientOrDie()
 				defer utilio.Close(conn)

--- a/cmd/argocd/commands/app_actions.go
+++ b/cmd/argocd/commands/app_actions.go
@@ -150,17 +150,18 @@ func NewApplicationResourceActionsRunCommand(clientOpts *argocdclient.ClientOpti
 	var all bool
 	command := &cobra.Command{
 		Use:   "run APPNAME ACTION",
-		Short: "Runs an available action on resource(s)",
+		Short: "Runs an available action on resource(s) matching the specified filters.",
+		Long:  "All filters except --kind are optional. Use --all to run the action on all matching resources if more than one resource matches the filters. Actions may only be run on resources that are represented in git and cannot be run on child resources.",
 		Example: templates.Examples(`
 	# Run an available action for an application
 	argocd app actions run APPNAME ACTION --kind KIND [--resource-name RESOURCE] [--namespace NAMESPACE] [--group GROUP]
 	`),
 	}
 
-	command.Flags().StringVar(&resourceName, "resource-name", "", "Name of resource")
-	command.Flags().StringVar(&namespace, "namespace", "", "Namespace")
-	command.Flags().StringVar(&kind, "kind", "", "Kind")
-	command.Flags().StringVar(&group, "group", "", "Group")
+	command.Flags().StringVar(&resourceName, "resource-name", "", "Name of resource on which the action should be run")
+	command.Flags().StringVar(&namespace, "namespace", "", "Namespace of the resource on which the action should be run")
+	command.Flags().StringVar(&kind, "kind", "", "Kind of the resource on which the action should be run")
+	command.Flags().StringVar(&group, "group", "", "Group of the resource on which the action should be run")
 	errors.CheckError(command.MarkFlagRequired("kind"))
 	command.Flags().BoolVar(&all, "all", false, "Indicates whether to run the action on multiple matching resources")
 

--- a/cmd/argocd/commands/project.go
+++ b/cmd/argocd/commands/project.go
@@ -35,6 +35,7 @@ type policyOpts struct {
 	action     string
 	permission string
 	object     string
+	resource   string
 }
 
 // NewProjectCommand returns a new instance of an `argocd proj` command
@@ -91,6 +92,7 @@ func addPolicyFlags(command *cobra.Command, opts *policyOpts) {
 	command.Flags().StringVarP(&opts.action, "action", "a", "", "Action to grant/deny permission on (e.g. get, create, list, update, delete)")
 	command.Flags().StringVarP(&opts.permission, "permission", "p", "allow", "Whether to allow or deny access to object with the action.  This can only be 'allow' or 'deny'")
 	command.Flags().StringVarP(&opts.object, "object", "o", "", "Object within the project to grant/deny access.  Use '*' for a wildcard. Will want access to '<project>/<object>'")
+	command.Flags().StringVarP(&opts.resource, "resource", "r", "applications", "Resource e.g. 'applications', 'applicationsets', 'logs', 'exec', etc.")
 }
 
 func humanizeTimestamp(epoch int64) string {

--- a/cmd/argocd/commands/repocreds.go
+++ b/cmd/argocd/commands/repocreds.go
@@ -189,7 +189,7 @@ func NewRepoCredsAddCommand(clientOpts *argocdclient.ClientOptions) *cobra.Comma
 	command.Flags().StringVar(&repo.BearerToken, "bearer-token", "", "bearer token to the Git repository")
 	command.Flags().StringVar(&sshPrivateKeyPath, "ssh-private-key-path", "", "path to the private ssh key (e.g. ~/.ssh/id_rsa)")
 	command.Flags().StringVar(&tlsClientCertPath, "tls-client-cert-path", "", "path to the TLS client cert (must be PEM format)")
-	command.Flags().StringVar(&tlsClientCertKeyPath, "tls-client-cert-key-path", "", "path to the TLS client cert's key path (must be PEM format)")
+	command.Flags().StringVar(&tlsClientCertKeyPath, "tls-client-cert-key-path", "", "path to the TLS client cert's key (must be PEM format)")
 	command.Flags().Int64Var(&repo.GithubAppId, "github-app-id", 0, "id of the GitHub Application")
 	command.Flags().Int64Var(&repo.GithubAppInstallationId, "github-app-installation-id", 0, "installation id of the GitHub Application")
 	command.Flags().StringVar(&githubAppPrivateKeyPath, "github-app-private-key-path", "", "private key of the GitHub Application")

--- a/cmd/util/repo.go
+++ b/cmd/util/repo.go
@@ -38,7 +38,7 @@ func AddRepoFlags(command *cobra.Command, opts *RepoOptions) {
 	command.Flags().StringVar(&opts.Repo.BearerToken, "bearer-token", "", "bearer token to the Git BitBucket Data Center repository")
 	command.Flags().StringVar(&opts.SshPrivateKeyPath, "ssh-private-key-path", "", "path to the private ssh key (e.g. ~/.ssh/id_rsa)")
 	command.Flags().StringVar(&opts.TlsClientCertPath, "tls-client-cert-path", "", "path to the TLS client cert (must be PEM format)")
-	command.Flags().StringVar(&opts.TlsClientCertKeyPath, "tls-client-cert-key-path", "", "path to the TLS client cert's key path (must be PEM format)")
+	command.Flags().StringVar(&opts.TlsClientCertKeyPath, "tls-client-cert-key-path", "", "path to the TLS client cert's key (must be PEM format)")
 	command.Flags().BoolVar(&opts.InsecureIgnoreHostKey, "insecure-ignore-host-key", false, "disables SSH strict host key checking (deprecated, use --insecure-skip-server-verification instead)")
 	command.Flags().BoolVar(&opts.InsecureSkipServerVerification, "insecure-skip-server-verification", false, "disables server certificate and host key checks")
 	command.Flags().BoolVar(&opts.EnableLfs, "enable-lfs", false, "enable git-lfs (Large File Support) on this repository")

--- a/cmpserver/plugin/config.go
+++ b/cmpserver/plugin/config.go
@@ -74,7 +74,8 @@ func ReadPluginConfig(filePath string) (*PluginConfig, error) {
 		return nil, err
 	}
 
-	if err = ValidatePluginConfig(config); err != nil {
+	err = ValidatePluginConfig(config)
+	if err != nil {
 		return nil, err
 	}
 

--- a/docs/developer-guide/tilt.md
+++ b/docs/developer-guide/tilt.md
@@ -1,0 +1,148 @@
+# Tilt Development
+
+[Tilt](https://tilt.dev/) provides a real-time web UI that offers better visibility into logs, health status, and dependencies, making debugging easier compared to relying solely on terminal outputs. With a single `tilt up` command, developers can spin up all required services without managing multiple processes manually, simplifying the local development workflow. Tilt also integrates seamlessly with Docker and Kubernetes, allowing for efficient container-based development. Unlike goreman, which lacks dynamic config reloading, Tilt can detect and apply changes to Kubernetes YAML and Helm charts without full restarts, making it more efficient for iterative development.
+
+### Prerequisites
+* kubernetes environment (kind, minikube, k3d, etc.)
+* tilt (`brew install tilt`)
+* kustomize
+* kubectl
+
+### Running
+1. Spin up environment by running `tilt up` in the root directory of the repo
+    * Resources will be deployed into the `argocd` namespace in the cluster that your `kubeconfig` is currently pointed to. 
+
+2. Use `ctrl+c` to close tilt which stops watching files for changes and closes port-forwards. Everything deployed to the local cluster will be left in tact and continue to run. Run `tilt up` again to start up another session and pick up where you left off.   
+
+### Cleanup
+To remove all deployed resources in your local cluster including CRDs, run `tilt down` from the root of the repo. 
+
+### Port Forwarding
+Port forwarding is automatically setup from the cluster to localhost host for the folling ports:
+
+| Deployment | API | Metrics | Webhook | Debug |
+|------------|-----|---------|---------|-------|
+| argocd-server | 8080 | 8083 | | 9345 |
+| argocd-repo-server | 8081 | 8084 | | 9346 |
+| argocd-redis | 6379 | | | |
+| argocd-applicationset-controller | | 8085 | 7000 | 9347 |
+| argocd-application-controller | | 8086 | | 9348 |
+| argocd-notifications-controller | | 8087 | | 9349 |
+| argocd-commit-server | 8089 | 8088 | | 9350 |
+
+### Debugging ArgoCD
+Each deployed pod running ArgoCD components uses delve to expose a debug port. Tilt is configured to forward each of those ports locally to `localhost`. IDEs can attach to the corresponding application to set break points and debug code running inside the cluster. 
+
+| Deployment | Debug Host Port |
+|-----------|------------|
+| argocd-server | localhost:9345 |
+| argocd-repo-server | localhost:9346 |
+| argocd-applicationset-controller | localhost:9347 |
+| argocd-application-controller | localhost:9348 |
+| argocd-notifications-controller | localhost:9349 |
+| argocd-commit-server | localhost:9350 |
+
+
+#### VS Code
+Add a `.vscode/launch.json` file with these configurations to support attaching to running pods corresponding to the service. 
+
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Connect to server",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "remotePath": "${workspaceFolder}",
+            "port": 9345,
+            "host": "127.0.0.1"
+        },
+        {
+            "name": "Connect to repo-server",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "remotePath": "${workspaceFolder}",
+            "port": 9346,
+            "host": "127.0.0.1"
+        },
+        {
+            "name": "Connect to applicationset-controller",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "remotePath": "${workspaceFolder}",
+            "port": 9347,
+            "host": "127.0.0.1"
+        },
+        {
+            "name": "Connect to application-controller",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "remotePath": "${workspaceFolder}",
+            "port": 9348,
+            "host": "127.0.0.1"
+        },
+        {
+            "name": "Connect to notifications-controller",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "remotePath": "${workspaceFolder}",
+            "port": 9349,
+            "host": "127.0.0.1"
+        },
+        {
+            "name": "Connect to commit-server",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "remotePath": "${workspaceFolder}",
+            "port": 9350,
+            "host": "127.0.0.1"
+        }
+    ]
+}
+```
+
+#### Goland
+Add a `.run/remote-debugging.run.xml` file with these configurations to support attaching to running pods corresponding to the service. 
+
+```xml
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Connect to server" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" focusToolWindowBeforeRun="true" port="9345">
+        <option name="disconnectOption" value="LEAVE" />
+        <disconnect value="LEAVE" />
+        <method v="2" />
+    </configuration>
+    <configuration default="false" name="Connect to repo-server" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" focusToolWindowBeforeRun="true" port="9346">
+        <option name="disconnectOption" value="LEAVE" />
+        <disconnect value="LEAVE" />
+        <method v="2" />
+    </configuration>
+    <configuration default="false" name="Connect to applicationset-controller" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" focusToolWindowBeforeRun="true" port="9347">
+        <option name="disconnectOption" value="LEAVE" />
+        <disconnect value="LEAVE" />
+        <method v="2" />
+    </configuration>
+    <configuration default="false" name="Connect to application-controller" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" focusToolWindowBeforeRun="true" port="9348">
+        <option name="disconnectOption" value="LEAVE" />
+        <disconnect value="LEAVE" />
+        <method v="2" />
+    </configuration>
+    <configuration default="false" name="Connect to notifications-controller" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" focusToolWindowBeforeRun="true" port="9349">
+        <option name="disconnectOption" value="LEAVE" />
+        <disconnect value="LEAVE" />
+        <method v="2" />
+    </configuration>
+    <configuration default="false" name="Connect to commit-server" type="GoRemoteDebugConfigurationType" factoryName="Go Remote" focusToolWindowBeforeRun="true" port="9350">
+        <option name="disconnectOption" value="LEAVE" />
+        <disconnect value="LEAVE" />
+        <method v="2" />
+    </configuration>
+</component>
+```

--- a/docs/operator-manual/applicationset.yaml
+++ b/docs/operator-manual/applicationset.yaml
@@ -5,31 +5,66 @@ metadata:
   namespace: argocd
 spec:
   generators:
+    # The list generator generates a set of two application which then filter by the key value to only select the env with value staging
+    - list:
+        elements:
+          - cluster: engineering-dev
+            url: https://kubernetes.default.svc
+            env: staging
+          - cluster: engineering-prod
+            url: https://kubernetes.default.svc
+            env: prod
+        # The generator's template field takes precedence over the spec's template fields
+        template:
+          metadata: {}
+          spec:
+            project: "default"
+            source:
+              revision: HEAD
+              repoURL: https://github.com/argoproj/argo-cd.git
+              # New path value is generated here:
+              path: 'applicationset/examples/template-override/{{cluster}}-override'
+            destination: {}
 
-    # Using a generator plugin without combining it with Matrix or Merge
-    # Plugins allow you to provide your own generator
-    - plugin:
-      # Specify the configMap where the plugin configuration is located.
-      configMapRef:
-        name: my-plugin
-      # You can pass arbitrary parameters to the plugin. `input.parameters` is a map, but values may be any type.
-      # These parameters will also be available on the generator's output under the `generator.input.parameters` key.
-      input:
-        parameters:
-          key1: "value1"
-          key2: "value2"
-          list: ["list", "of", "values"]
-          boolean: true
-          map:
-            key1: "value1"
-            key2: "value2"
-            key3: "value3"
-        # You can also attach arbitrary values to the generator's output under the `values` key. These values will be
-        # available in templates under the `values` key.
+      # Selector allows to post-filter all generator.
+      selector:
+        matchLabels:
+          env: staging
+          
+    # It is also possible to use matchExpressions for more powerful selectors
+    - clusters: {}
+      selector:
+        matchExpressions:
+          - key: server
+            operator: In
+            values:
+              - https://kubernetes.default.svc
+              - https://some-other-cluster
+
+    # Git generator generates parametes either from directory structure of files within a git repo
+    - git:
+        repoURL: https://github.com/argoproj/argo-cd.git
+        # OPTIONAL: use directory structure of git repo to generate parameters
+        directories:
+        - path: applicationset/examples/git-generator-directory/excludes/cluster-addons/*
+        - path: applicationset/examples/git-generator-directory/excludes/cluster-addons/exclude-helm-guestbook
+          exclude: true # Exclude directory when generating parameters
+        # OPTIONAL: generates parameters using the contents of JSON/YAML files found in git repo
+        files:
+        - path: "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
+        - path: "applicationset/examples/git-generator-files-discovery/cluster-config/*/dev/config.json"
+          exclude: true # Exclude file when generating parameters
+        revision: HEAD
+        # OPTIONAL: Checks for changes every 60sec (default 3min)
+        requeueAfterSeconds: 60
+        # The generator's template field takes precedence over the spec's template fields
+        template:
+        # OPTIONAL: all path-related parameter names will be prefixed with the specified value and a dot separator
+        pathParamPrefix: myRepo
+        # OPTIONAL: Values contains key/value pairs which are passed directly as parameters to the template
         values:
-          value1: something
-        # When using a Plugin generator, the ApplicationSet controller polls every `requeueAfterSeconds` interval (defaulting to every 30 minutes) to detect changes.
-        requeueAfterSeconds: 30
+          cluster: '{{.path.basename}}'
+
 
     # to automatically discover repositories within an organization
     - scmProvider:
@@ -76,6 +111,65 @@ spec:
         - repositoryMatch: ^otherapp
           pathsExist: [helm]
           pathsDoNotExist: [disabledrepo.txt]
+
+    # Cluster-decision-resource-based ApplicationSet generator
+    - clusterDecisionResource:
+      # ConfigMap with GVK information for the duck type resource
+      configMapRef: my-configmap  
+      name: quak           # Choose either "name" of the resource or "labelSelector"
+      labelSelector:
+        matchLabels:       # OPTIONAL
+          duck: spotted
+        matchExpressions:  # OPTIONAL
+        - key: duck
+          operator: In
+          values:
+          - "spotted"
+          - "canvasback"   
+      # OPTIONAL: Checks for changes every 60sec (default 3min)
+      requeueAfterSeconds: 60
+  
+    # The Pull Request generator uses the API of an SCMaaS provider to automatically discover open pull requests within a repository
+    - pullRequest:
+        # When using a Pull Request generator, the ApplicationSet controller polls every `requeueAfterSeconds` interval (defaulting to every 30 minutes) to detect changes.
+        requeueAfterSeconds: 1800
+        # See below for provider specific options.
+        # Specify the repository from which to fetch the GitHub Pull requests.
+        github:
+          # The GitHub organization or user.
+          owner: myorg
+          # The Github repository
+          repo: myrepository
+          # For GitHub Enterprise (optional)
+          api: https://git.example.com/
+          # Reference to a Secret containing an access token. (optional)
+          tokenRef:
+            secretName: github-token
+            key: token
+          # (optional) use a GitHub App to access the API instead of a PAT.
+          appSecretName: github-app-repo-creds
+          # Labels is used to filter the PRs that you want to target. (optional)
+          labels:
+          - preview
+
+        # Filters allow selecting which pull requests to generate for
+        # Include any pull request ending with "argocd". (optional)
+        filters:
+        - branchMatch: ".*-argocd"
+
+        # Specify the project from which to fetch the GitLab merge requests.
+        gitlab:
+        # Specify the repository from which to fetch the Gitea Pull requests.
+        gitea:
+        # Fetch pull requests from a repo hosted on a Bitbucket Server (not the same as Bitbucket Cloud).
+        bitbucketServer:
+        # Fetch pull requests from a repo hosted on a Bitbucket Cloud.
+        bitbucket:
+        # Specify the organization, project and repository from which you want to fetch pull requests.
+        azuredevops:
+        # Fetch pull requests from AWS CodeCommit repositories.
+        awsCodeCommit:
+   
     # matrix 'parent' generator
     - matrix:
         generators:
@@ -106,6 +200,31 @@ spec:
               elements: 
                 - server: https://2.4.6.8
                   values.redis: 'true'
+
+    # Using a generator plugin without combining it with Matrix or Merge
+    # Plugins allow you to provide your own generator
+    - plugin:
+      # Specify the configMap where the plugin configuration is located.
+      configMapRef:
+        name: my-plugin
+      # You can pass arbitrary parameters to the plugin. `input.parameters` is a map, but values may be any type.
+      # These parameters will also be available on the generator's output under the `generator.input.parameters` key.
+      input:
+        parameters:
+          key1: "value1"
+          key2: "value2"
+          list: ["list", "of", "values"]
+          boolean: true
+          map:
+            key1: "value1"
+            key2: "value2"
+            key3: "value3"
+        # You can also attach arbitrary values to the generator's output under the `values` key. These values will be
+        # available in templates under the `values` key.
+        values:
+          value1: something
+        # When using a Plugin generator, the ApplicationSet controller polls every `requeueAfterSeconds` interval (defaulting to every 30 minutes) to detect changes.
+        requeueAfterSeconds: 30
                 
               
   # Determines whether go templating will be used in the `template` field below.
@@ -206,94 +325,4 @@ spec:
     jqPathExpressions:
     - .spec.source.helm.values
 
-  # Cluster-decision-resource-based ApplicationSet generator
-  - clusterDecisionResource:
-    # ConfigMap with GVK information for the duck type resource
-    configMapRef: my-configmap  
-    name: quak           # Choose either "name" of the resource or "labelSelector"
-    labelSelector:
-      matchLabels:       # OPTIONAL
-        duck: spotted
-      matchExpressions:  # OPTIONAL
-      - key: duck
-        operator: In
-        values:
-        - "spotted"
-        - "canvasback"   
-    # OPTIONAL: Checks for changes every 60sec (default 3min)
-    requeueAfterSeconds: 60
   
-  # The Pull Request generator uses the API of an SCMaaS provider to automatically discover open pull requests within a repository
-  - pullRequest:
-      # When using a Pull Request generator, the ApplicationSet controller polls every `requeueAfterSeconds` interval (defaulting to every 30 minutes) to detect changes.
-      requeueAfterSeconds: 1800
-      # See below for provider specific options.
-      # Specify the repository from which to fetch the GitHub Pull requests.
-      github:
-        # The GitHub organization or user.
-        owner: myorg
-        # The Github repository
-        repo: myrepository
-        # For GitHub Enterprise (optional)
-        api: https://git.example.com/
-        # Reference to a Secret containing an access token. (optional)
-        tokenRef:
-          secretName: github-token
-          key: token
-        # (optional) use a GitHub App to access the API instead of a PAT.
-        appSecretName: github-app-repo-creds
-        # Labels is used to filter the PRs that you want to target. (optional)
-        labels:
-        - preview
-
-      # Filters allow selecting which pull requests to generate for
-      # Include any pull request ending with "argocd". (optional)
-      filters:
-      - branchMatch: ".*-argocd"
-
-      # Specify the project from which to fetch the GitLab merge requests.
-      gitlab:
-      # Specify the repository from which to fetch the Gitea Pull requests.
-      gitea:
-      # Fetch pull requests from a repo hosted on a Bitbucket Server (not the same as Bitbucket Cloud).
-      bitbucketServer:
-      # Fetch pull requests from a repo hosted on a Bitbucket Cloud.
-      bitbucket:
-      # Specify the organization, project and repository from which you want to fetch pull requests.
-      azuredevops:
-      # Fetch pull requests from AWS CodeCommit repositories.
-      awsCodeCommit:
-
-# The list generator generates a set of two application which then filter by the key value to only select the env with value staging
-  - list:
-      elements:
-        - cluster: engineering-dev
-          url: https://kubernetes.default.svc
-          env: staging
-        - cluster: engineering-prod
-          url: https://kubernetes.default.svc
-          env: prod
-      # The generator's template field takes precedence over the spec's template fields
-      template:
-        metadata: {}
-        spec:
-          project: "default"
-          source:
-            revision: HEAD
-            repoURL: https://github.com/argoproj/argo-cd.git
-            # New path value is generated here:
-            path: 'applicationset/examples/template-override/{{cluster}}-override'
-          destination: {}
-
-    selector:
-      matchLabels:
-        env: staging
-  # It is also possible to use matchExpressions for more powerful selectors
-  - clusters: {}
-    selector:
-      matchExpressions:
-        - key: server
-          operator: In
-          values:
-            - https://kubernetes.default.svc
-            - https://some-other-cluster

--- a/docs/operator-manual/upgrading/3.0-3.1.md
+++ b/docs/operator-manual/upgrading/3.0-3.1.md
@@ -1,23 +1,21 @@
 # v3.0 to 3.1
 
-## Symlink protection in API `--staticassets` directory
-
-The `--staticassets` directory in the API server (`/app/shared` by default) is now protected against out-of-bounds 
-symlinks. This is to help protect against symlink attacks. If you have any symlinks in your `--staticassets` directory
-to a location outside the directory, they will return a 500 error starting with 3.1.
-
-## Breaking Changes
-
-### Kube versions
+## No more KubeVersions variable modification
 
 Until v3.0, Argo CD removed `+` identifier from `kubeVersions` in Helm, Kustomize and Plugins. For example, if Argo CD receive `kubeVersions` as vX.Y.Z+, we convert to vX.Y.Z internally. Starting with v3.1, the internal conversation is entirely removed.
 
-#### Detection
+### Detection
 
 To detect if you are affected, check the `kubeVersions` you are using. If you use `kubeVersions` including `+` identifier, the application must be failed when you upgrade from v3.0 to v3.1.
 
-#### Remediation
+### Remediation
 
 The plus symbol was originally removed [because Helm did not support it](https://github.com/argoproj/argo-cd/issues/2303). Helm no longer enforces this restriction, so apps should work fine even if your kubeVersions include `+`.
 
 However, since Argo CD now sends unmodified kubeVersions to Helm, the generated manifests may differ due to the changed kubeVersions. For apps which require extra caution, it may be advisable to disable auto-sync, upgrade, check any diffs, and then reenable auto-sync.
+
+## Symlink protection in API `--staticassets` directory
+
+The `--staticassets` directory in the API server (`/app/shared` by default) is now protected against out-of-bounds
+symlinks. This is to help protect against symlink attacks. If you have any symlinks in your `--staticassets` directory
+to a location outside the directory, they will return a 500 error starting with 3.1.

--- a/docs/operator-manual/upgrading/overview.md
+++ b/docs/operator-manual/upgrading/overview.md
@@ -7,12 +7,12 @@
 
 Argo CD uses semver-like versioning that ensures the following rules:
 
-* The patch release does not introduce any breaking changes. So if you are upgrading from v1.5.1 to v1.5.3
+- The patch release does not introduce any breaking changes. So if you are upgrading from v1.5.1 to v1.5.3
   there should be no special instructions to follow.
-* The minor release might introduce minor changes with a workaround. If you are upgrading from v1.3.0 to v1.5.2
-  please make sure to check upgrading details in both [v1.3 to v1.4](./1.3-1.4.md)  and  [v1.4 to v1.5](./1.4-1.5.md)
+- The minor release might introduce minor changes with a workaround. If you are upgrading from v1.3.0 to v1.5.2
+  please make sure to check upgrading details in both [v1.3 to v1.4](./1.3-1.4.md) and [v1.4 to v1.5](./1.4-1.5.md)
   upgrading instructions.
-* The major release introduces backward incompatible behavior changes. It is recommended to take a backup of
+- The major release introduces backward incompatible behavior changes. It is recommended to take a backup of
   Argo CD settings using the [disaster recovery guide](../disaster_recovery.md).
 
 After reading the relevant notes about possible breaking changes introduced in a new Argo CD version, use the following
@@ -38,27 +38,28 @@ kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/<v
 
 <hr/>
 
-* [v2.14 to v3.0](./2.14-3.0.md)
-* [v2.13 to v2.14](./2.13-2.14.md)
-* [v2.12 to v2.13](./2.12-2.13.md)
-* [v2.11 to v2.12](./2.11-2.12.md)
-* [v2.10 to v2.11](./2.10-2.11.md)
-* [v2.9 to v2.10](./2.9-2.10.md)
-* [v2.8 to v2.9](./2.8-2.9.md)
-* [v2.7 to v2.8](./2.7-2.8.md)
-* [v2.6 to v2.7](./2.6-2.7.md)
-* [v2.5 to v2.6](./2.5-2.6.md)
-* [v2.4 to v2.5](./2.4-2.5.md)
-* [v2.3 to v2.4](./2.3-2.4.md)
-* [v2.2 to v2.3](./2.2-2.3.md)
-* [v2.1 to v2.2](./2.1-2.2.md)
-* [v2.0 to v2.1](./2.0-2.1.md)
-* [v1.8 to v2.0](./1.8-2.0.md)
-* [v1.7 to v1.8](./1.7-1.8.md)
-* [v1.6 to v1.7](./1.6-1.7.md)
-* [v1.5 to v1.6](./1.5-1.6.md)
-* [v1.4 to v1.5](./1.4-1.5.md)
-* [v1.3 to v1.4](./1.3-1.4.md)
-* [v1.2 to v1.3](./1.2-1.3.md)
-* [v1.1 to v1.2](./1.1-1.2.md)
-* [v1.0 to v1.1](./1.0-1.1.md)
+- [v3.0 to v3.1](./3.0-3.1.md)
+- [v2.14 to v3.0](./2.14-3.0.md)
+- [v2.13 to v2.14](./2.13-2.14.md)
+- [v2.12 to v2.13](./2.12-2.13.md)
+- [v2.11 to v2.12](./2.11-2.12.md)
+- [v2.10 to v2.11](./2.10-2.11.md)
+- [v2.9 to v2.10](./2.9-2.10.md)
+- [v2.8 to v2.9](./2.8-2.9.md)
+- [v2.7 to v2.8](./2.7-2.8.md)
+- [v2.6 to v2.7](./2.6-2.7.md)
+- [v2.5 to v2.6](./2.5-2.6.md)
+- [v2.4 to v2.5](./2.4-2.5.md)
+- [v2.3 to v2.4](./2.3-2.4.md)
+- [v2.2 to v2.3](./2.2-2.3.md)
+- [v2.1 to v2.2](./2.1-2.2.md)
+- [v2.0 to v2.1](./2.0-2.1.md)
+- [v1.8 to v2.0](./1.8-2.0.md)
+- [v1.7 to v1.8](./1.7-1.8.md)
+- [v1.6 to v1.7](./1.6-1.7.md)
+- [v1.5 to v1.6](./1.5-1.6.md)
+- [v1.4 to v1.5](./1.4-1.5.md)
+- [v1.3 to v1.4](./1.3-1.4.md)
+- [v1.2 to v1.3](./1.2-1.3.md)
+- [v1.1 to v1.2](./1.1-1.2.md)
+- [v1.0 to v1.1](./1.0-1.1.md)

--- a/docs/operator-manual/user-management/google.md
+++ b/docs/operator-manual/user-management/google.md
@@ -162,7 +162,7 @@ Go through the same steps as in [OpenID Connect using Dex](#openid-connect-using
 ### Set up Directory API access
 
 1. Follow [Google instructions to create a service account with Domain-Wide Delegation](https://developers.google.com/admin-sdk/directory/v1/guides/delegation)
-   - When assigning API scopes to the service account assign **only** the `https://www.googleapis.com/auth/admin.directory.group.readonly` scope and nothing else. If you assign any other scopes, you won't be able to fetch information from the API
+   - When assigning API scopes to the service account, the scope must **strictly include** `https://www.googleapis.com/auth/admin.directory.group.readonly`. If you assign only the [broader scope] (https://www.googleapis.com/auth/admin.directory.group), you will not be able to retrieve data from the API
    - Create the credentials in JSON format and store them in a safe place, we'll need them later
 2. Enable the [Admin SDK](https://console.developers.google.com/apis/library/admin.googleapis.com/)
 

--- a/docs/user-guide/best_practices.md
+++ b/docs/user-guide/best_practices.md
@@ -14,8 +14,8 @@ from your application source code, is highly recommended for the following reaso
    cleaner Git history of what changes were made, without the noise coming from check-ins due to
    normal development activity.
 
-3. Your application may be comprised of services built from multiple Git repositories, but is
-   deployed as a single unit. Oftentimes, microservices applications are comprised of services
+3. Your application may comprise services built from multiple Git repositories, but is
+   deployed as a single unit. Oftentimes, microservices applications comprise services
    with different versioning schemes, and release cycles (e.g. ELK, Kafka + ZooKeeper). It may not
    make sense to store the manifests in one of the source code repositories of a single component.
 

--- a/docs/user-guide/commands/argocd_admin_repo_generate-spec.md
+++ b/docs/user-guide/commands/argocd_admin_repo_generate-spec.md
@@ -37,13 +37,13 @@ argocd admin repo generate-spec REPOURL [flags]
   argocd admin repo generate-spec helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type helm --name stable --enable-oci --username test --password test
 
   # Add a private HTTPS OCI repository named 'stable'
-  argocd repo generate-spec oci://helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type oci --name stable --username test --password test
+  argocd admin repo generate-spec oci://helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type oci --name stable --username test --password test
   
   # Add a private OCI repository named 'stable' without verifying the server's TLS certificate
-  argocd repo generate-spec oci://helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type oci --name stable --username test --password test --insecure-skip-server-verification
+  argocd admin repo generate-spec oci://helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type oci --name stable --username test --password test --insecure-skip-server-verification
   
   # Add a private HTTP OCI repository named 'stable'
-  argocd repo generate-spec oci://helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type oci --name stable --username test --password test --insecure-oci-force-http
+  argocd admin repo generate-spec oci://helm-oci-registry.cn-zhangjiakou.cr.aliyuncs.com --type oci --name stable --username test --password test --insecure-oci-force-http
 
 ```
 
@@ -70,7 +70,7 @@ argocd admin repo generate-spec REPOURL [flags]
       --project string                          project of the repository
       --proxy string                            use proxy to access repository
       --ssh-private-key-path string             path to the private ssh key (e.g. ~/.ssh/id_rsa)
-      --tls-client-cert-key-path string         path to the TLS client cert's key path (must be PEM format)
+      --tls-client-cert-key-path string         path to the TLS client cert's key (must be PEM format)
       --tls-client-cert-path string             path to the TLS client cert (must be PEM format)
       --type string                             type of the repository, "git", "oci" or "helm" (default "git")
       --use-azure-workload-identity             whether to use azure workload identity for authentication

--- a/docs/user-guide/commands/argocd_app_actions.md
+++ b/docs/user-guide/commands/argocd_app_actions.md
@@ -59,5 +59,5 @@ argocd app actions [flags]
 
 * [argocd app](argocd_app.md)	 - Manage applications
 * [argocd app actions list](argocd_app_actions_list.md)	 - Lists available actions on a resource
-* [argocd app actions run](argocd_app_actions_run.md)	 - Runs an available action on resource(s)
+* [argocd app actions run](argocd_app_actions_run.md)	 - Runs an available action on resource(s) matching the specified filters.
 

--- a/docs/user-guide/commands/argocd_app_actions_run.md
+++ b/docs/user-guide/commands/argocd_app_actions_run.md
@@ -2,7 +2,11 @@
 
 ## argocd app actions run
 
-Runs an available action on resource(s)
+Runs an available action on resource(s) matching the specified filters.
+
+### Synopsis
+
+All filters except --kind are optional. Use --all to run the action on all matching resources if more than one resource matches the filters. Actions may only be run on resources that are represented in git and cannot be run on child resources.
 
 ```
 argocd app actions run APPNAME ACTION [flags]
@@ -19,11 +23,11 @@ argocd app actions run APPNAME ACTION [flags]
 
 ```
       --all                    Indicates whether to run the action on multiple matching resources
-      --group string           Group
+      --group string           Group of the resource on which the action should be run
   -h, --help                   help for run
-      --kind string            Kind
-      --namespace string       Namespace
-      --resource-name string   Name of resource
+      --kind string            Kind of the resource on which the action should be run
+      --namespace string       Namespace of the resource on which the action should be run
+      --resource-name string   Name of resource on which the action should be run
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_add-policy.md
+++ b/docs/user-guide/commands/argocd_proj_role_add-policy.md
@@ -35,6 +35,21 @@ JWT Tokens:
 ID          ISSUED-AT                                EXPIRES-AT
 1696759698  2023-10-08T11:08:18+01:00 (3 hours ago)  <none>
 
+# Add a new policy to allow get logs to the project
+$ argocd proj role add-policy test-project test-role -a get -p allow -o project -r logs
+
+# Policy should be updated
+$  argocd proj role get test-project test-role
+Role Name:     test-role
+Description:
+Policies:
+p, proj:test-project:test-role, projects, get, test-project, allow
+p, proj:test-project:test-role, applications, update, test-project/project, allow
+p, proj:test-project:test-role, logs, get, test-project/project, allow
+JWT Tokens:
+ID          ISSUED-AT                                EXPIRES-AT
+1696759698  2023-10-08T11:08:18+01:00 (3 hours ago)  <none>
+
 ```
 
 ### Options
@@ -44,6 +59,7 @@ ID          ISSUED-AT                                EXPIRES-AT
   -h, --help                help for add-policy
   -o, --object string       Object within the project to grant/deny access.  Use '*' for a wildcard. Will want access to '<project>/<object>'
   -p, --permission string   Whether to allow or deny access to object with the action.  This can only be 'allow' or 'deny' (default "allow")
+  -r, --resource string     Resource e.g. 'applications', 'applicationsets', 'logs', 'exec', etc. (default "applications")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_proj_role_remove-policy.md
+++ b/docs/user-guide/commands/argocd_proj_role_remove-policy.md
@@ -18,12 +18,28 @@ Description:
 Policies:
 p, proj:test-project:test-role, projects, get, test-project, allow
 p, proj:test-project:test-role, applications, update, test-project/project, allow
+p, proj:test-project:test-role, logs, get, test-project/project, allow
 JWT Tokens:
 ID          ISSUED-AT                                EXPIRES-AT
 1696759698  2023-10-08T11:08:18+01:00 (3 hours ago)  <none>
 
 # Remove the policy to allow update to objects
 $ argocd proj role remove-policy test-project test-role -a update -p allow -o project
+
+# The role should be removed now.
+$ argocd proj role get test-project test-role
+Role Name:     test-role
+Description:
+Policies:
+p, proj:test-project:test-role, projects, get, test-project, allow
+p, proj:test-project:test-role, logs, get, test-project/project, allow
+JWT Tokens:
+ID          ISSUED-AT                                EXPIRES-AT
+1696759698  2023-10-08T11:08:18+01:00 (4 hours ago)  <none>
+
+
+# Remove the logs read policy
+$ argocd proj role remove-policy test-project test-role -a get -p allow -o project -r logs
 
 # The role should be removed now.
 $ argocd proj role get test-project test-role
@@ -44,6 +60,7 @@ ID          ISSUED-AT                                EXPIRES-AT
   -h, --help                help for remove-policy
   -o, --object string       Object within the project to grant/deny access.  Use '*' for a wildcard. Will want access to '<project>/<object>'
   -p, --permission string   Whether to allow or deny access to object with the action.  This can only be 'allow' or 'deny' (default "allow")
+  -r, --resource string     Resource e.g. 'applications', 'applicationsets', 'logs', 'exec', etc. (default "applications")
 ```
 
 ### Options inherited from parent commands

--- a/docs/user-guide/commands/argocd_repo_add.md
+++ b/docs/user-guide/commands/argocd_repo_add.md
@@ -80,7 +80,7 @@ argocd repo add REPOURL [flags]
       --project string                          project of the repository
       --proxy string                            use proxy to access repository
       --ssh-private-key-path string             path to the private ssh key (e.g. ~/.ssh/id_rsa)
-      --tls-client-cert-key-path string         path to the TLS client cert's key path (must be PEM format)
+      --tls-client-cert-key-path string         path to the TLS client cert's key (must be PEM format)
       --tls-client-cert-path string             path to the TLS client cert (must be PEM format)
       --type string                             type of the repository, "git", "oci" or "helm" (default "git")
       --upsert                                  Override an existing repository with the same name even if the spec differs

--- a/docs/user-guide/commands/argocd_repocreds_add.md
+++ b/docs/user-guide/commands/argocd_repocreds_add.md
@@ -49,7 +49,7 @@ argocd repocreds add REPOURL [flags]
       --password string                         password to the repository
       --proxy-url string                        If provided, this URL will be used to connect via proxy
       --ssh-private-key-path string             path to the private ssh key (e.g. ~/.ssh/id_rsa)
-      --tls-client-cert-key-path string         path to the TLS client cert's key path (must be PEM format)
+      --tls-client-cert-key-path string         path to the TLS client cert's key (must be PEM format)
       --tls-client-cert-path string             path to the TLS client cert (must be PEM format)
       --type string                             type of the repository, "git" or "helm" (default "git")
       --upsert                                  Override an existing repository with the same name even if the spec differs

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/gosimple/slug v1.15.0
-	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
+	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-retryablehttp v0.7.7

--- a/go.sum
+++ b/go.sum
@@ -503,8 +503,8 @@ github.com/gregdel/pushover v1.3.1/go.mod h1:EcaO66Nn1StkpEm1iKtBTV3d2A16SoMsVER
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
-github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 h1:qnpSQwGEnkcRpTqNOIR6bJbR0gAorgP9CSALpRcKoAA=
-github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1/go.mod h1:lXGCsh6c22WGtjr+qGHj1otzZpV/1kwTMAqkwZsnWRU=
+github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
+github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 h1:sGm2vDRFUrQJO/Veii4h4zG2vvqG6uWNkBHSTqXOZk0=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2/go.mod h1:wd1YpapPLivG6nQgbf7ZkG1hhSOXDhhn4MLTknx2aAc=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=

--- a/manifests/dev-tilt/kustomization.yaml
+++ b/manifests/dev-tilt/kustomization.yaml
@@ -1,0 +1,141 @@
+# This manifest is used by Tilt to deploy the argocd resources to the cluster.
+namespace: argocd
+
+resources:
+  - namespace.yaml
+  - ui-deployment.yaml
+  - ../cluster-install-with-hydrator
+
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: argocd-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: argocd
+      - op: remove
+        path: /spec/template/spec/containers/0/securityContext
+      - op: add
+        path: /spec/template/spec/containers/0/ports/0
+        value:
+          name: debug
+          containerPort: 2345
+
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: argocd-repo-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: argocd
+      - op: replace
+        path: /spec/template/spec/initContainers/0/image
+        value: argocd-job
+      - op: remove
+        path: /spec/template/spec/containers/0/securityContext
+      - op: remove
+        path: /spec/template/spec/initContainers/0/securityContext
+      - op: add
+        path: /spec/template/spec/containers/0/ports/0
+        value:
+          name: debug
+          containerPort: 2345
+
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: argocd-commit-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: argocd
+      - op: remove
+        path: /spec/template/spec/containers/0/securityContext
+      - op: add
+        path: /spec/template/spec/containers/0/ports/0
+        value:
+          name: debug
+          containerPort: 2345
+
+  - target:
+      group: apps
+      version: v1
+      kind: StatefulSet
+      name: argocd-application-controller
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: argocd
+      - op: remove
+        path: /spec/template/spec/containers/0/securityContext
+      - op: add
+        path: /spec/template/spec/containers/0/ports/0
+        value:
+          name: debug
+          containerPort: 2345
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: argocd-dex-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/initContainers/0/image
+        value: argocd-job
+      - op: remove
+        path: /spec/template/spec/initContainers/0/securityContext
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: argocd-notifications-controller
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: argocd
+      - op: remove
+        path: /spec/template/spec/containers/0/securityContext
+      - op: remove
+        path: /spec/template/spec/securityContext
+      - op: add
+        path: /spec/template/spec/containers/0/ports
+        value:
+          - name: debug
+            containerPort: 2345
+          - name: metrics
+            containerPort: 9001
+
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: argocd-applicationset-controller
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: argocd
+      - op: remove
+        path: /spec/template/spec/containers/0/securityContext
+      - op: add
+        path: /spec/template/spec/containers/0/ports/0
+        value:
+          name: debug
+          containerPort: 2345
+
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: argocd-redis
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/initContainers/0/image
+        value: argocd-job
+      - op: remove
+        path: /spec/template/spec/initContainers/0/securityContext

--- a/manifests/dev-tilt/namespace.yaml
+++ b/manifests/dev-tilt/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd

--- a/manifests/dev-tilt/ui-deployment.yaml
+++ b/manifests/dev-tilt/ui-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-ui
+spec:
+  selector:
+    matchLabels:
+      app: argocd-ui
+  template:
+    metadata:
+      labels:
+        app: argocd-ui
+    spec:
+      containers:
+        - name: argocd-ui
+          image: argocd-ui
+          env:
+            - name: ARGOCD_API_URL
+              value: https://argocd-server
+            - name: ARGOCD_E2E_YARN_HOST
+              value: "0.0.0.0"
+          ports:
+            - containerPort: 4000
+              name: http

--- a/manifests/dev-tilt/ui-service.yaml
+++ b/manifests/dev-tilt/ui-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-ui
+spec:
+  selector:
+    app: argocd-ui
+  ports:
+    - port: 4000
+      targetPort: http

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -222,6 +222,7 @@ nav:
     - developer-guide/extensions/ui-extensions.md
     - developer-guide/extensions/proxy-extensions.md
   - developer-guide/faq.md
+  - developer-guide/tilt.md
 - faq.md
 - security_considerations.md
 - Support: SUPPORT.md

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1067,7 +1067,8 @@ func (s *Server) Patch(ctx context.Context, q *application.ApplicationPatchReque
 		return nil, err
 	}
 
-	if err = s.enf.EnforceErr(ctx.Value("claims"), rbac.ResourceApplications, rbac.ActionUpdate, app.RBACName(s.ns)); err != nil {
+	err = s.enf.EnforceErr(ctx.Value("claims"), rbac.ResourceApplications, rbac.ActionUpdate, app.RBACName(s.ns))
+	if err != nil {
 		return nil, err
 	}
 
@@ -2455,7 +2456,8 @@ func (s *Server) getUnstructuredLiveResourceOrApp(ctx context.Context, rbacReque
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
-		if err = s.enf.EnforceErr(ctx.Value("claims"), rbac.ResourceApplications, rbacRequest, app.RBACName(s.ns)); err != nil {
+		err = s.enf.EnforceErr(ctx.Value("claims"), rbac.ResourceApplications, rbacRequest, app.RBACName(s.ns))
+		if err != nil {
 			return nil, nil, nil, nil, err
 		}
 		config, err = s.getApplicationClusterConfig(ctx, app)

--- a/server/applicationset/applicationset.go
+++ b/server/applicationset/applicationset.go
@@ -122,7 +122,8 @@ func (s *Server) Get(ctx context.Context, q *applicationset.ApplicationSetGetQue
 	if err != nil {
 		return nil, fmt.Errorf("error getting ApplicationSet: %w", err)
 	}
-	if err = s.enf.EnforceErr(ctx.Value("claims"), rbac.ResourceApplicationSets, rbac.ActionGet, a.RBACName(s.ns)); err != nil {
+	err = s.enf.EnforceErr(ctx.Value("claims"), rbac.ResourceApplicationSets, rbac.ActionGet, a.RBACName(s.ns))
+	if err != nil {
 		return nil, err
 	}
 
@@ -248,7 +249,8 @@ func (s *Server) Create(ctx context.Context, q *applicationset.ApplicationSetCre
 	if !q.Upsert {
 		return nil, status.Errorf(codes.InvalidArgument, "existing ApplicationSet spec is different, use upsert flag to force update")
 	}
-	if err = s.enf.EnforceErr(ctx.Value("claims"), rbac.ResourceApplicationSets, rbac.ActionUpdate, appset.RBACName(s.ns)); err != nil {
+	err = s.enf.EnforceErr(ctx.Value("claims"), rbac.ResourceApplicationSets, rbac.ActionUpdate, appset.RBACName(s.ns))
+	if err != nil {
 		return nil, err
 	}
 	updated, err := s.updateAppSet(ctx, existing, appset, true)
@@ -347,7 +349,8 @@ func (s *Server) ResourceTree(ctx context.Context, q *applicationset.Application
 	if err != nil {
 		return nil, fmt.Errorf("error getting ApplicationSet: %w", err)
 	}
-	if err = s.enf.EnforceErr(ctx.Value("claims"), rbac.ResourceApplicationSets, rbac.ActionGet, a.RBACName(s.ns)); err != nil {
+	err = s.enf.EnforceErr(ctx.Value("claims"), rbac.ResourceApplicationSets, rbac.ActionGet, a.RBACName(s.ns))
+	if err != nil {
 		return nil, err
 	}
 

--- a/test/e2e/app_management_ns_test.go
+++ b/test/e2e/app_management_ns_test.go
@@ -2131,7 +2131,7 @@ spec:
 		And(func(app *Application) {
 			assert.Equal(t, map[string]string{"labels.local/from-file": "file", "labels.local/from-args": "args"}, app.Labels)
 			assert.Equal(t, map[string]string{"annotations.local/from-file": "file"}, app.Annotations)
-			assert.Equal(t, []string{"resources-finalizer.argocd.argoproj.io"}, app.Finalizers)
+			assert.Equal(t, []string{ResourcesFinalizerName}, app.Finalizers)
 			assert.Equal(t, path, app.Spec.GetSource().Path)
 			assert.Equal(t, []HelmParameter{{Name: "foo", Value: "foo"}}, app.Spec.GetSource().Helm.Parameters)
 		})

--- a/test/e2e/app_management_test.go
+++ b/test/e2e/app_management_test.go
@@ -2350,7 +2350,7 @@ spec:
 		And(func(app *Application) {
 			assert.Equal(t, map[string]string{"labels.local/from-file": "file", "labels.local/from-args": "args"}, app.Labels)
 			assert.Equal(t, map[string]string{"annotations.local/from-file": "file"}, app.Annotations)
-			assert.Equal(t, []string{"resources-finalizer.argocd.argoproj.io"}, app.Finalizers)
+			assert.Equal(t, []string{ResourcesFinalizerName}, app.Finalizers)
 			assert.Equal(t, path, app.Spec.GetSource().Path)
 			assert.Equal(t, []HelmParameter{{Name: "foo", Value: "foo"}}, app.Spec.GetSource().Helm.Parameters)
 		})

--- a/test/e2e/applicationset_git_generator_test.go
+++ b/test/e2e/applicationset_git_generator_test.go
@@ -40,7 +40,7 @@ func TestSimpleGitDirectoryGenerator(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -149,7 +149,7 @@ func TestSimpleGitDirectoryGeneratorGoTemplate(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -281,7 +281,7 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -379,7 +379,7 @@ func TestSimpleGitDirectoryGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -463,7 +463,7 @@ func TestSimpleGitFilesGenerator(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -595,7 +595,7 @@ func TestSimpleGitFilesGeneratorGPGEnabledUnsignedCommits(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: project,
@@ -693,7 +693,7 @@ func TestSimpleGitFilesGeneratorGPGEnabledWithoutKnownKeys(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: project,
@@ -772,7 +772,7 @@ func TestSimpleGitFilesGeneratorGoTemplate(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -1003,7 +1003,7 @@ func TestGitGeneratorPrivateRepo(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -1080,7 +1080,7 @@ func TestGitGeneratorPrivateRepoGoTemplate(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -1157,7 +1157,7 @@ func TestSimpleGitGeneratorPrivateRepoWithNoRepo(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -1232,7 +1232,7 @@ func TestSimpleGitGeneratorPrivateRepoWithMatchingProject(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -1308,7 +1308,7 @@ func TestSimpleGitGeneratorPrivateRepoWithMismatchingProject(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -1384,7 +1384,7 @@ func TestGitGeneratorPrivateRepoWithTemplatedProject(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -1471,7 +1471,7 @@ func TestGitGeneratorPrivateRepoWithTemplatedProjectAndProjectScopedRepo(t *test
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       name,
 				Namespace:  fixture.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",

--- a/test/e2e/applicationset_test.go
+++ b/test/e2e/applicationset_test.go
@@ -60,7 +60,7 @@ func TestSimpleListGeneratorExternalNamespace(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook",
 			Namespace:  externalNamespace,
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -162,7 +162,7 @@ func TestSimpleListGeneratorExternalNamespaceNoConflict(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook",
 			Namespace:  externalNamespace,
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -186,7 +186,7 @@ func TestSimpleListGeneratorExternalNamespaceNoConflict(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook",
 			Namespace:  externalNamespace2,
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -345,7 +345,7 @@ func TestSimpleListGenerator(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -436,7 +436,7 @@ func TestSimpleListGeneratorGoTemplate(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -528,7 +528,7 @@ func TestRenderHelmValuesObject(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -603,7 +603,7 @@ func TestTemplatePatch(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			Annotations: map[string]string{
 				"annotation-some-key": "annotation-some-value",
 			},
@@ -730,7 +730,7 @@ func TestUpdateHelmValuesObject(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -815,7 +815,7 @@ func TestSyncPolicyCreateUpdate(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook-sync-policy-create-update",
 			Namespace:  utils.ArgoCDNamespace,
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -844,7 +844,7 @@ func TestSyncPolicyCreateUpdate(t *testing.T) {
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{
 					Name:       "{{.cluster}}-guestbook-sync-policy-create-update",
-					Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+					Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 				},
 				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
@@ -929,7 +929,7 @@ func TestSyncPolicyCreateDelete(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook-sync-policy-create-delete",
 			Namespace:  utils.ArgoCDNamespace,
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -1028,7 +1028,7 @@ func TestSyncPolicyCreateOnly(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook-sync-policy-create-only",
 			Namespace:  utils.ArgoCDNamespace,
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -1056,7 +1056,7 @@ func TestSyncPolicyCreateOnly(t *testing.T) {
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{
 					Name:       "{{.cluster}}-guestbook-sync-policy-create-only",
-					Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+					Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 				},
 				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
@@ -1342,7 +1342,7 @@ func TestSimpleSCMProviderGenerator(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "argo-cd-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -1417,7 +1417,7 @@ func TestSimpleSCMProviderGeneratorGoTemplate(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "argo-cd-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -1487,7 +1487,7 @@ func TestSCMProviderGeneratorSCMProviderNotAllowed(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "argo-cd-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -1563,7 +1563,7 @@ func TestCustomApplicationFinalizers(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io/background"},
+			Finalizers: []string{v1alpha1.BackgroundPropagationPolicyFinalizer},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -1589,7 +1589,7 @@ func TestCustomApplicationFinalizers(t *testing.T) {
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{
 					Name:       "{{cluster}}-guestbook",
-					Finalizers: []string{"resources-finalizer.argocd.argoproj.io/background"},
+					Finalizers: []string{v1alpha1.BackgroundPropagationPolicyFinalizer},
 				},
 				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
@@ -1630,7 +1630,7 @@ func TestCustomApplicationFinalizersGoTemplate(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "my-cluster-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io/background"},
+			Finalizers: []string{v1alpha1.BackgroundPropagationPolicyFinalizer},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -1657,7 +1657,7 @@ func TestCustomApplicationFinalizersGoTemplate(t *testing.T) {
 			Template: v1alpha1.ApplicationSetTemplate{
 				ApplicationSetTemplateMeta: v1alpha1.ApplicationSetTemplateMeta{
 					Name:       "{{.cluster}}-guestbook",
-					Finalizers: []string{"resources-finalizer.argocd.argoproj.io/background"},
+					Finalizers: []string{v1alpha1.BackgroundPropagationPolicyFinalizer},
 				},
 				Spec: v1alpha1.ApplicationSpec{
 					Project: "default",
@@ -1744,7 +1744,7 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictOk(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "argo-cd-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -1846,7 +1846,7 @@ func TestSimpleSCMProviderGeneratorTokenRefStrictKo(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "argo-cd-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			Labels: map[string]string{
 				common.LabelKeyAppInstance: "simple-scm-provider-generator-strict-ko",
 			},
@@ -1955,7 +1955,7 @@ func TestSimplePullRequestGenerator(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "guestbook-1",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -2033,7 +2033,7 @@ func TestSimplePullRequestGeneratorGoTemplate(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "guestbook-1",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			Labels:     map[string]string{"app": "preview"},
 		},
 		Spec: v1alpha1.ApplicationSpec{
@@ -2109,7 +2109,7 @@ func TestPullRequestGeneratorNotAllowedSCMProvider(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "guestbook-1",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			Labels: map[string]string{
 				"app": "preview",
 			},

--- a/test/e2e/cluster_generator_test.go
+++ b/test/e2e/cluster_generator_test.go
@@ -24,7 +24,7 @@ func TestSimpleClusterGeneratorExternalNamespace(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "cluster1-guestbook",
 			Namespace:  externalNamespace,
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -124,7 +124,7 @@ func TestSimpleClusterGenerator(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "cluster1-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -218,7 +218,7 @@ func TestClusterGeneratorWithLocalCluster(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "in-cluster-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -335,7 +335,7 @@ func TestSimpleClusterGeneratorAddingCluster(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "{{name}}-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -417,7 +417,7 @@ func TestSimpleClusterGeneratorDeletingCluster(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "{{name}}-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -501,7 +501,7 @@ func TestClusterGeneratorWithFlatListMode(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "flat-clusters",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",

--- a/test/e2e/clusterdecisiongenerator_e2e_test.go
+++ b/test/e2e/clusterdecisiongenerator_e2e_test.go
@@ -27,7 +27,7 @@ func TestSimpleClusterDecisionResourceGeneratorExternalNamespace(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "cluster1-guestbook",
 			Namespace:  externalNamespace,
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -135,7 +135,7 @@ func TestSimpleClusterDecisionResourceGenerator(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "cluster1-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -237,7 +237,7 @@ func TestSimpleClusterDecisionResourceGeneratorAddingCluster(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "{{name}}-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -332,7 +332,7 @@ func TestSimpleClusterDecisionResourceGeneratorDeletingClusterSecret(t *testing.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "{{name}}-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",
@@ -429,7 +429,7 @@ func TestSimpleClusterDecisionResourceGeneratorDeletingClusterFromResource(t *te
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "{{name}}-guestbook",
 			Namespace:  fixture.TestNamespace(),
-			Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+			Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 		},
 		Spec: v1alpha1.ApplicationSpec{
 			Project: "default",

--- a/test/e2e/matrix_e2e_test.go
+++ b/test/e2e/matrix_e2e_test.go
@@ -24,7 +24,7 @@ func TestListMatrixGenerator(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       fmt.Sprintf("%s-%s", cluster, name),
 				Namespace:  utils.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -147,7 +147,7 @@ func TestClusterMatrixGenerator(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       fmt.Sprintf("%s-%s", cluster, name),
 				Namespace:  utils.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -273,7 +273,7 @@ func TestMatrixTerminalMatrixGeneratorSelector(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       fmt.Sprintf("%s-%s", cluster, name),
 				Namespace:  utils.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -414,7 +414,7 @@ func TestMatrixTerminalMergeGeneratorSelector(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       fmt.Sprintf("%s-%s", name, nameSuffix),
 				Namespace:  utils.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",

--- a/test/e2e/merge_e2e_test.go
+++ b/test/e2e/merge_e2e_test.go
@@ -25,7 +25,7 @@ func TestListMergeGenerator(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       fmt.Sprintf("%s-%s", name, nameSuffix),
 				Namespace:  utils.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -146,7 +146,7 @@ func TestClusterMergeGenerator(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       fmt.Sprintf("%s-%s-%s", cluster, name, nameSuffix),
 				Namespace:  utils.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",
@@ -290,7 +290,7 @@ func TestMergeTerminalMergeGeneratorSelector(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:       fmt.Sprintf("%s-%s", name, nameSuffix),
 				Namespace:  utils.TestNamespace(),
-				Finalizers: []string{"resources-finalizer.argocd.argoproj.io"},
+				Finalizers: []string{v1alpha1.ResourcesFinalizerName},
 			},
 			Spec: v1alpha1.ApplicationSpec{
 				Project: "default",

--- a/ui/src/app/applications/components/application-details/application-resource-list.tsx
+++ b/ui/src/app/applications/components/application-details/application-resource-list.tsx
@@ -59,12 +59,12 @@ export const ApplicationResourceList = (props: ApplicationResourceListProps) => 
                     <div className='argo-table-list__head'>
                         <div className='row'>
                             <div className='columns small-1 xxxlarge-1' />
-                            <div className='columns small-2 xxxlarge-1'>NAME</div>
+                            <div className='columns small-2 xxxlarge-2'>NAME</div>
                             <div className='columns small-1 xxxlarge-1'>GROUP/KIND</div>
                             <div className='columns small-1 xxxlarge-1'>SYNC ORDER</div>
                             <div className='columns small-2 xxxlarge-1'>NAMESPACE</div>
                             {isSameKind && props.resources[0].kind === 'ReplicaSet' && <div className='columns small-1 xxxlarge-1'>REVISION</div>}
-                            <div className='columns small-2 xxxlarge-1'>CREATED AT</div>
+                            <div className='columns small-2 xxxlarge-2'>CREATED AT</div>
                             <div className='columns small-2 xxxlarge-1'>STATUS</div>
                         </div>
                     </div>
@@ -88,7 +88,7 @@ export const ApplicationResourceList = (props: ApplicationResourceListProps) => 
                                             </div>
                                         </div>
                                         <Tooltip content={res.name} enabled={!!res.name}>
-                                            <div className='columns small-2 xxxlarge-1 application-details__item'>
+                                            <div className='columns small-2 xxxlarge-2 application-details__item'>
                                                 <span className='application-details__item_text'>{res.name}</span>
                                                 {res.kind === 'Application' && (
                                                     <Consumer>
@@ -128,7 +128,7 @@ export const ApplicationResourceList = (props: ApplicationResourceListProps) => 
                                                     );
                                                 })}
                                         <Tooltip content={res.createdAt} enabled={!!res.createdAt}>
-                                            <div className='columns small-2 xxxlarge-1'>
+                                            <div className='columns small-2 xxxlarge-2'>
                                                 {res.createdAt && (
                                                     <span>
                                                         <Moment fromNow={true} ago={true}>

--- a/ui/src/app/applications/components/applications-list/applications-labels.tsx
+++ b/ui/src/app/applications/components/applications-list/applications-labels.tsx
@@ -8,7 +8,7 @@ import './applications-labels.scss';
 export const ApplicationsLabels = ({app}: {app: Application}) => {
     const labels = (
         <>
-            <span className='application-labels__item'>{getAppDefaultSource(app).targetRevision || 'HEAD'}</span>
+            <span className='application-labels__item'>{getAppDefaultSource(app)?.targetRevision || 'HEAD'}</span>
             {Object.keys(app.metadata.labels || {}).map(label => (
                 <span className='application-labels__item' key={label}>{`${label}=${app.metadata.labels[label]}`}</span>
             ))}

--- a/util/argo/normalizers/knowntypes_normalizer.go
+++ b/util/argo/normalizers/knowntypes_normalizer.go
@@ -102,7 +102,8 @@ func normalize(obj map[string]any, field knownTypeField, fieldPath []string) err
 					}
 					items[j] = newItem
 				} else {
-					if err = normalize(item, field, subPath); err != nil {
+					err = normalize(item, field, subPath)
+					if err != nil {
 						return err
 					}
 				}

--- a/util/cache/appstate/cache.go
+++ b/util/cache/appstate/cache.go
@@ -88,7 +88,8 @@ func (c *Cache) GetAppResourcesTree(appName string, res *appv1.ApplicationTree) 
 	if res.ShardsCount > 1 {
 		for i := int64(1); i < res.ShardsCount; i++ {
 			var shard appv1.ApplicationTree
-			if err = c.GetItem(appResourcesTreeKey(appName, i), &shard); err != nil {
+			err = c.GetItem(appResourcesTreeKey(appName, i), &shard)
+			if err != nil {
 				return err
 			}
 			res.Merge(&shard)

--- a/util/db/cluster.go
+++ b/util/db/cluster.go
@@ -112,7 +112,8 @@ func (db *db) CreateCluster(ctx context.Context, c *appv1.Cluster) (*appv1.Clust
 		},
 	}
 
-	if err = clusterToSecret(c, clusterSecret); err != nil {
+	err = clusterToSecret(c, clusterSecret)
+	if err != nil {
 		return nil, err
 	}
 

--- a/util/db/repository.go
+++ b/util/db/repository.go
@@ -180,7 +180,8 @@ func (db *db) listRepositories(ctx context.Context, repoType *string, writeCreds
 	if err != nil {
 		return nil, err
 	}
-	if err = db.enrichCredsToRepos(ctx, repositories); err != nil {
+	err = db.enrichCredsToRepos(ctx, repositories)
+	if err != nil {
 		return nil, err
 	}
 

--- a/util/oci/client.go
+++ b/util/oci/client.go
@@ -434,7 +434,8 @@ func saveCompressedImageToPath(ctx context.Context, digest string, repo oras.Rea
 	}
 
 	// Remove redundant ingest folder; this is an artifact from the oras.Copy call above
-	if err = os.RemoveAll(path.Join(tempDir, "ingest")); err != nil {
+	err = os.RemoveAll(path.Join(tempDir, "ingest"))
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `964f269..9849d27`
**Files Changed:** 56 (28 programming files)
**Programming Ratio:** 50.0%

**Commits included:**
- docs: Explain repo definition for source hydrators (#23454)
- chore(lint): enable filepathJoin rule from go-critic (#23453)
- docs: Docs usage fix (#23450)
- fix(ui): make Name column wider (argoproj#21080) (#21375)
- chore(lint): enable sloppyReassign rule from go-critic (#23443)
- docs: Clarify Google Directory API scope requirements in documentation (#23386)
- chore: initial support for tilt based development (#22337) (#23002)
- fix: #23041 Add resource support to 'argocd proj role add-policy/remove-policy' (#23213)
- chore(deps): bump github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus from 1.0.1 to 1.1.0 (#23441)
- docs: regroup generators reference fixes #23439 (#23440)
... and 5 more commits